### PR TITLE
Fix inputs with empty string

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -2,10 +2,17 @@ require 'json'
 require 'octokit'
 require_relative './services/merge_branch_service'
 
+def presence(value)
+  return nil if value == ""
+  value
+end
+
 @event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
-@head_to_merge = ENV['INPUT_HEAD_TO_MERGE'] || ENV['INPUT_FROM_BRANCH'] || ENV['GITHUB_SHA'] # or brach name
+@head_to_merge = presence(ENV['INPUT_HEAD_TO_MERGE']) || presence(ENV['INPUT_FROM_BRANCH']) || ENV['GITHUB_SHA'] # or brach name
 @repository = ENV['GITHUB_REPOSITORY']
-@github_token = ENV['INPUT_GITHUB_TOKEN'] || ENV['GITHUB_TOKEN']
+@github_token = presence(ENV['INPUT_GITHUB_TOKEN']) || ENV['GITHUB_TOKEN']
+
+puts "@head_to_merge: #{@head_to_merge}, empty string: #{@head_to_merge == ''}, default: #{ENV['GITHUB_SHA']}"
 
 inputs = {
   type: ENV['INPUT_TYPE'] || MergeBrachService::TYPE_LABELED, # labeled | comment | now

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -12,7 +12,7 @@ end
 @repository = ENV['GITHUB_REPOSITORY']
 @github_token = presence(ENV['INPUT_GITHUB_TOKEN']) || ENV['GITHUB_TOKEN']
 
-puts "@head_to_merge: #{@head_to_merge}, empty string: #{@head_to_merge == ''}, default: #{ENV['GITHUB_SHA']}"
+puts "@head_to_merge: #{@head_to_merge}, empty string: #{ENV['INPUT_HEAD_TO_MERGE'] == ''}, default: #{ENV['GITHUB_SHA']}"
 
 inputs = {
   type: ENV['INPUT_TYPE'] || MergeBrachService::TYPE_LABELED, # labeled | comment | now

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -8,12 +8,12 @@ def presence(value)
 end
 
 @event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
-@head_to_merge = presence(ENV['INPUT_HEAD_TO_MERGE']) || presence(ENV['INPUT_FROM_BRANCH']) || ENV['GITHUB_SHA'] # or brach name
+@head_to_merge = presence(ENV['INPUT_HEAD_TO_MERGE']) || presence(ENV['INPUT_FROM_BRANCH']) || presence(ENV['GITHUB_SHA']) # or brach name
 @repository = ENV['GITHUB_REPOSITORY']
-@github_token = presence(ENV['INPUT_GITHUB_TOKEN']) || ENV['GITHUB_TOKEN']
+@github_token = presence(ENV['INPUT_GITHUB_TOKEN']) || presence(ENV['GITHUB_TOKEN'])
 
 inputs = {
-  type: ENV['INPUT_TYPE'] || MergeBrachService::TYPE_LABELED, # labeled | comment | now
+  type: presence(ENV['INPUT_TYPE']) || MergeBrachService::TYPE_LABELED, # labeled | comment | now
   label_name: ENV['INPUT_LABEL_NAME'],
   target_branch: ENV['INPUT_TARGET_BRANCH']
 }

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -12,8 +12,6 @@ end
 @repository = ENV['GITHUB_REPOSITORY']
 @github_token = presence(ENV['INPUT_GITHUB_TOKEN']) || ENV['GITHUB_TOKEN']
 
-puts "@head_to_merge: #{@head_to_merge}, empty string: #{ENV['INPUT_HEAD_TO_MERGE'] == ''}, default: #{ENV['GITHUB_SHA']}"
-
 inputs = {
   type: ENV['INPUT_TYPE'] || MergeBrachService::TYPE_LABELED, # labeled | comment | now
   label_name: ENV['INPUT_LABEL_NAME'],


### PR DESCRIPTION
Fix read value from `GITHUB_SHA` or `INPUT_FROM_BRANCH`, checking empty string values.

Examples:

```yaml
name: Merge any release branch to uat
on:
  push:
    branches:
      - 'release/*'
jobs:
  merge-branch:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@master

      - name: Merge staging -> uat
        uses: devmasx/merge-branch@v1.3.0
        with:
          type: now
          target_branch: uat
          github_token: ${{ github.token }}
```

or 

```yaml
name: Sync multiple branches
on:
  push:
    branches:
      - '*'
jobs:
  sync-branch:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@master

      - name: Merge development -> staging
        uses: devmasx/merge-branch@v1.3.0
        with:
          type: now
          from_branch: development
          target_branch: staging
          github_token: ${{ github.token }}
```