### PR TITLE
feat: Support Github Enterprise

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -7,6 +7,10 @@ def presence(value)
   value
 end
 
+Octokit.configure do |c|
+  c.api_endpoint = ENV['GITHUB_API_URL']
+end
+
 @event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
 @head_to_merge = presence(ENV['INPUT_HEAD_TO_MERGE']) || presence(ENV['INPUT_FROM_BRANCH']) || presence(ENV['GITHUB_SHA']) # or brach name
 @repository = ENV['GITHUB_REPOSITORY']


### PR DESCRIPTION
I followed the [official doc here](https://github.com/octokit/octokit.rb#interacting-with-the-githubcom-apis-in-github-enterprise) added support for github enterprise.

Tested on my hosted github enterprise.