### PR TITLE
Fix checking target branch and label name.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'octokit'
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,26 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    diff-lcs (1.4.4)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     multipart-post (2.1.1)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (4.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -18,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   octokit
+  rspec
 
 BUNDLED WITH
    1.17.2

--- a/lib/services/merge_branch_service.rb
+++ b/lib/services/merge_branch_service.rb
@@ -6,9 +6,9 @@ class MergeBrachService
 
   def self.validate_inputs!(target_branch:, type:, label_name:)
     raise "Invalid type" unless [TYPE_LABELED, TYPE_NOW].include?(type)
-    raise "Empty target branch" unless target_branch
+    raise "Empty target branch" if target_branch.nil? || target_branch.empty?
     if type == TYPE_LABELED
-      raise "Empty target label name" unless label_name
+      raise "Empty target label name" if label_name.nil? || label_name.empty?
     end
   end
 

--- a/spec/merge_brach_service_spec.rb
+++ b/spec/merge_brach_service_spec.rb
@@ -33,6 +33,30 @@ describe MergeBrachService do
       end
     end
 
+    context "with empty label name" do
+      let(:label_name) { '' }
+
+      it ".validate_inputs!" do
+        expect { MergeBrachService.validate_inputs!(inputs) }.to raise_error()
+      end
+    end
+
+    context "with invalid target branch" do
+      let(:target_branch) { nil }
+
+      it ".validate_inputs!" do
+        expect { MergeBrachService.validate_inputs!(inputs) }.to raise_error()
+      end
+    end
+
+    context "with empty target branch" do
+      let(:target_branch) { '' }
+
+      it ".validate_inputs!" do
+        expect { MergeBrachService.validate_inputs!(inputs) }.to raise_error()
+      end
+    end
+
     context "not match label" do
       let(:event) { { 'action' => 'labeled', 'label' => { 'name' => 'other label' } } }
 


### PR DESCRIPTION
We found that it is not raised error from merge-branch action when target_branch and label_name are empty strings.

When we set empty strings to the target_branch in yaml file and executed GitHub Actions in the personal repository, the Actions failed.
https://github.com/M-Yamashita01/RubySample/runs/4042641757?check_suite_focus=true

And when we set empty strings to the label_name in yaml file and executed GitHub Actions, the error should have been raised, but the Actions passed it by mistake.
https://github.com/M-Yamashita01/RubySample/runs/4051426151?check_suite_focus=true

Therefore, we fixed them and added rspec gem and tests.