### PR TITLE
New option to disable fastforwards so that Github does not add empty commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   message:
     description: 'Commit message'
     required: false
+  disable_fastforwards:
+    description: 'Does not merge the branch if no files have been changed'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -27,9 +27,15 @@ service = MergeBrachService.new(inputs, @event)
 
 if service.valid?
   @client = Octokit::Client.new(access_token: @github_token)
-  puts "Running perform merge target_branch: #{inputs[:target_branch]} @head_to_merge: #{@head_to_merge}}"
-  @client.merge(@repository, inputs[:target_branch], @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})
-  puts "Completed: Finish merge branch #{@head_to_merge} to #{inputs[:target_branch]}"
+
+  comparison = @client.compare(@repository, inputs[:target_branch], @head_to_merge)
+  if comparison.status == 'identical' && presence(ENV['INPUT_DISABLE_FASTFORWARDS']) && ENV['INPUT_DISABLE_FASTFORWARDS'] == "true"
+    puts "Neutral: skip fastforward merge target_branch: #{inputs[:target_branch]} @head_to_merge: #{@head_to_merge}"
+  else
+    puts "Running perform merge target_branch: #{inputs[:target_branch]} @head_to_merge: #{@head_to_merge}}"
+    @client.merge(@repository, inputs[:target_branch], @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})
+    puts "Completed: Finish merge branch #{@head_to_merge} to #{inputs[:target_branch]}"
+  end
 else
   puts "Neutral: skip merge target_branch: #{inputs[:target_branch]} @head_to_merge: #{@head_to_merge}"
 end


### PR DESCRIPTION
I was experiencing a situation where this github action was polluting my commit log with empty commits because it merges fast forwards with no file changes..

![image](https://user-images.githubusercontent.com/409265/151109545-24a53bf3-1c83-4bcf-9af8-da84b1898e60.png)

This pull request adds a new feature and option to disable this behavior. You can add the option `disable_fastforwards: true` and have this action skip merging if it finds that no files were changed between the branches.

![image](https://user-images.githubusercontent.com/409265/151109846-a9619313-669d-4e3c-bcc5-83cfbe903519.png)

This can happen when you do the following:

1. Have merge-branch setup to merge master into staging
2. Update a file in branch staging and push to github
3. Merge the staging branch into master and push master branch to github

The merge-branch action will see the fast forward and run the merge action on the API making it be treated as a new commit which isn't doing anything. This feature will disable that from happening by calling the comparison API and checking if the branches are identical or not.