### PR TITLE
Add regex support to target_branch input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.idea

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -34,7 +34,7 @@ if service.valid?
       if branch.name.match?(inputs[:target_branch])
         puts "Running perform merge target_branch: #{branch.name} @head_to_merge: #{@head_to_merge}}"
         @client.merge(@repository, branch.name, @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})
-        puts "Completed: Finish merge branch #{@head_to_merge} to #{inputs[:target_branch]}"
+        puts "Completed: Finish merge branch #{@head_to_merge} to #{branch.name}"
       end
     end
     page_number += 1


### PR DESCRIPTION
This change, updates the target_branch input parameter, to be regex compatible.

All branches in the repo, will be iterated over looking for a regex branch name  match. On match, the changes will be auto-merged.

This maintains existing functionality, using the branch name explicitly, while also adding regex for advanced use cases