### PR TITLE
Add regex support to target_branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.idea

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -53,8 +53,8 @@ if service.valid?
 
   # github uses an env file for passing values as environment variables between concurrent job steps
   File.open(ENV['GITHUB_ENV'], 'a:UTF-8') do |env|
-    env << "MERGE_SUCCESS=#{merge_success.join(', ')}"
-    env << "MERGE_FAILURE=#{merge_failure.join(', ')}"
+    env.puts "MERGE_SUCCESS=#{merge_success.join(', ')}"
+    env.puts "MERGE_FAILURE=#{merge_failure.join(', ')}"
   end
 
   exit 1 if merge_failure.length.positive?

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -29,16 +29,33 @@ if service.valid?
   @client = Octokit::Client.new(access_token: @github_token)
 
   page_number = 1
+  merge_success = []
+  merge_failure = []
+
   while (page = @client.branches(@repository, page: page_number)).length.positive?
     page.each do |branch|
       if branch.name.match?(inputs[:target_branch])
         puts "Running perform merge target_branch: #{branch.name} @head_to_merge: #{@head_to_merge}}"
-        @client.merge(@repository, branch.name, @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})
-        puts "Completed: Finish merge branch #{@head_to_merge} to #{inputs[:target_branch]}"
+
+        if @client.merge(@repository, branch.name, @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})&.key?(sha)
+          puts "Completed: Finish merge branch #{@head_to_merge} to #{branch.name}"
+          merge_success << branch.name
+        else
+          puts "Error: Failed to merge branch #{@head_to_merge} to #{branch.name}"
+          merge_failure << branch.name
+        end
       end
     end
     page_number += 1
   end
+
+  # github uses an env file for passing values as environment variables between concurrent job steps
+  File.open(ENV['GITHUB_ENV'], 'a') do |env|
+    env << "MERGE_SUCCESS=#{merge_success.join(', ')}"
+    env << "MERGE_FAILURE=#{merge_failure.join(', ')}"
+  end
+
+  return merge_failure.length.positive? ? 1 : 0
 else
   puts "Neutral: skip merge target_branch: #{inputs[:target_branch]} @head_to_merge: #{@head_to_merge}"
 end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -38,14 +38,11 @@ if service.valid?
         puts "Running perform merge target_branch: #{branch.name} @head_to_merge: #{@head_to_merge}}"
 
         begin
-          if @client.merge(@repository, branch.name, @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})&.key?(sha)
-            puts "Completed: Finish merge branch #{@head_to_merge} to #{branch.name}"
-            merge_success << branch.name
-          else
-            puts "Error: Failed to merge branch #{@head_to_merge} to #{branch.name}"
-            merge_failure << branch.name
-          end
-        rescue StandardError
+          @client.merge(@repository, branch.name, @head_to_merge, ENV['INPUT_MESSAGE'] ? {commit_message: ENV['INPUT_MESSAGE']} : {})
+          puts "Completed: Finish merge branch #{@head_to_merge} to #{branch.name}"
+          merge_success << branch.name
+        rescue StandardError => exc
+          puts "#{exc.class} - #{exc.message}"
           puts "Error: Failed to merge branch #{@head_to_merge} to #{branch.name}"
           merge_failure << branch.name
         end


### PR DESCRIPTION
Changes consist of:

* `target_branch` is now a regex string
* All branches in the calling repository will be iterated over
  * Changes will be merged, if there branch name is a regex match to target_branch
* Two environment variables are set to document successful and failed merges.
  * MERGE_SUCCESS
  * MERGE_FAILURE
  * Contents will be a string, containing a comma separated list of branches that succeeded, or failed

## Merge failures
In the event of a merge failure, by any branch
* The job will continue to execute to completion.
* The entire job, will report as failed
  * This allows follow up jobs to be conditionally called in the event of success/failures(merge errors).