### PR TITLE
Add required token permissions to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ on:
 jobs:
   sync-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
 
@@ -46,6 +48,8 @@ on:
 jobs:
   merge-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
 
@@ -68,6 +72,8 @@ on:
 jobs:
   merge-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
 
@@ -97,6 +103,8 @@ on:
 jobs:
   merge-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
The action requires repository write permission. This adds the required token permission configuration at the job level using [jobs.<job_id>.permissions](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions) to the examples.